### PR TITLE
Remove redundant auth check

### DIFF
--- a/livemap/drf_views.py
+++ b/livemap/drf_views.py
@@ -28,7 +28,7 @@ class VideoStreamSourceViewSet(viewsets.ModelViewSet):
             queryset = queryset.filter(is_active=True)
 
         mark_in_use_until = self.request.query_params.get(MARK_IN_USE_UNTIL_PARAM)  # pyright: ignore[reportAttributeAccessIssue]
-        if mark_in_use_until and self.request.user.is_authenticated:
+        if mark_in_use_until:
             # 0) Validate the incoming ISO-8601 string.
             try:
                 in_use_until = datetime.fromisoformat(mark_in_use_until)


### PR DESCRIPTION
Currently, any request requires authentication. As a result, it's no longer required to check it for the `mark_in_use_until` parameter.